### PR TITLE
fix: use relative base path for built assets

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,12 @@ import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
+  // Use a relative base path so built assets are resolved correctly
+  // even when the application is served from a subdirectory. Without
+  // this configuration some hosts may return the HTML index file for
+  // asset requests, causing the browser to treat them as text/html and
+  // block module loading.
+  base: "./",
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary
- ensure Vite builds assets with relative paths so they're served with the correct MIME type

## Testing
- `npm run lint` *(fails: Unexpected any, etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899079c6ab0832e912f6f6c89b71811