### PR TITLE
feat: add admin dashboard authentication

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { AuthProvider } from "@/hooks/useAuth";
 import { ProtectedRoute } from "@/components/ProtectedRoute";
-import Index from "./pages/Index";
+import { AdminAuthProvider } from "@/hooks/useAdminAuth";
+import { AdminRoute } from "@/components/AdminRoute";
 import Dashboard from "./pages/Dashboard";
 import Auth from "./pages/Auth";
 import Map from "./pages/Map";
@@ -21,6 +22,8 @@ import Ranking from "./pages/Ranking";
 import Tutorial from "./pages/Tutorial";
 import TutorialLesson from "./pages/TutorialLesson";
 import NotFound from "./pages/NotFound";
+import AdminLogin from "./pages/AdminLogin";
+import AdminDashboard from "./pages/AdminDashboard";
 
 const queryClient = new QueryClient();
 
@@ -28,17 +31,27 @@ const App = () => (
   <StrictMode>
     <QueryClientProvider client={queryClient}>
       <AuthProvider>
-        <TooltipProvider>
-          <Toaster />
-          <Sonner />
-          <BrowserRouter>
-            <Routes>
-              <Route path="/" element={<Auth />} />
-              <Route path="/dashboard" element={
-                <ProtectedRoute>
-                  <Dashboard />
-                </ProtectedRoute>
-              } />
+        <AdminAuthProvider>
+          <TooltipProvider>
+            <Toaster />
+            <Sonner />
+            <BrowserRouter>
+              <Routes>
+                <Route path="/" element={<Auth />} />
+                <Route path="/admin-login" element={<AdminLogin />} />
+                <Route
+                  path="/admin-dashboard"
+                  element={
+                    <AdminRoute>
+                      <AdminDashboard />
+                    </AdminRoute>
+                  }
+                />
+                <Route path="/dashboard" element={
+                  <ProtectedRoute>
+                    <Dashboard />
+                  </ProtectedRoute>
+                } />
               <Route path="/map" element={
                 <ProtectedRoute>
                   <Map />
@@ -93,7 +106,8 @@ const App = () => (
               <Route path="*" element={<NotFound />} />
             </Routes>
           </BrowserRouter>
-        </TooltipProvider>
+          </TooltipProvider>
+        </AdminAuthProvider>
       </AuthProvider>
     </QueryClientProvider>
   </StrictMode>

--- a/src/components/AdminRoute.tsx
+++ b/src/components/AdminRoute.tsx
@@ -1,0 +1,11 @@
+import { Navigate } from 'react-router-dom';
+import { useAdminAuth } from '@/hooks/useAdminAuth';
+
+export function AdminRoute({ children }: { children: React.ReactNode }) {
+  const { isAdmin } = useAdminAuth();
+  if (!isAdmin) {
+    return <Navigate to="/admin-login" replace />;
+  }
+  return <>{children}</>;
+}
+

--- a/src/hooks/useAdminAuth.tsx
+++ b/src/hooks/useAdminAuth.tsx
@@ -1,0 +1,53 @@
+import { createContext, useContext, useState, ReactNode } from 'react';
+
+const ADMIN_USERNAME = 'admin';
+const ADMIN_PASSWORD = 'Fdwfdw24';
+
+interface AdminAuthContextType {
+  isAdmin: boolean;
+  login: (username: string, password: string) => boolean;
+  logout: () => void;
+}
+
+const AdminAuthContext = createContext<AdminAuthContextType | undefined>(undefined);
+
+export function AdminAuthProvider({ children }: { children: ReactNode }) {
+  const [isAdmin, setIsAdmin] = useState<boolean>(() => {
+    return typeof window !== 'undefined' && localStorage.getItem('isAdmin') === 'true';
+  });
+
+  const login = (username: string, password: string) => {
+    const verified = username === ADMIN_USERNAME && password === ADMIN_PASSWORD;
+    if (verified) {
+      setIsAdmin(true);
+      if (typeof window !== 'undefined') {
+        localStorage.setItem('isAdmin', 'true');
+      }
+    } else {
+      setIsAdmin(false);
+    }
+    return verified;
+  };
+
+  const logout = () => {
+    setIsAdmin(false);
+    if (typeof window !== 'undefined') {
+      localStorage.removeItem('isAdmin');
+    }
+  };
+
+  return (
+    <AdminAuthContext.Provider value={{ isAdmin, login, logout }}>
+      {children}
+    </AdminAuthContext.Provider>
+  );
+}
+
+export function useAdminAuth() {
+  const context = useContext(AdminAuthContext);
+  if (!context) {
+    throw new Error('useAdminAuth must be used within AdminAuthProvider');
+  }
+  return context;
+}
+

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -1,0 +1,31 @@
+import { useNavigate } from 'react-router-dom';
+import { useAdminAuth } from '@/hooks/useAdminAuth';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+
+const AdminDashboard = () => {
+  const { logout } = useAdminAuth();
+  const navigate = useNavigate();
+
+  const handleLogout = () => {
+    logout();
+    navigate('/admin-login', { replace: true });
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-900">
+      <Card className="bg-gray-800 border-gray-700">
+        <CardHeader>
+          <CardTitle className="text-white">Admin Dashboard</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-gray-300">Willkommen, Admin!</p>
+          <Button onClick={handleLogout}>Logout</Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default AdminDashboard;
+

--- a/src/pages/AdminLogin.tsx
+++ b/src/pages/AdminLogin.tsx
@@ -1,0 +1,63 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAdminAuth } from '@/hooks/useAdminAuth';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+const AdminLogin = () => {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const { login } = useAdminAuth();
+  const navigate = useNavigate();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const verified = login(username, password);
+    if (verified) {
+      navigate('/admin-dashboard', { replace: true });
+    } else {
+      setError('Ungültige Zugangsdaten');
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-900">
+      <Card className="w-full max-w-sm bg-gray-800 border-gray-700">
+        <CardHeader>
+          <CardTitle className="text-white">Admin Login</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <Label htmlFor="username" className="text-gray-300">Benutzername</Label>
+              <Input
+                id="username"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                className="bg-gray-700 text-white"
+              />
+            </div>
+            <div>
+              <Label htmlFor="password" className="text-gray-300">Passwort</Label>
+              <Input
+                id="password"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="bg-gray-700 text-white"
+              />
+            </div>
+            {error && <p className="text-red-500 text-sm">{error}</p>}
+            <Button type="submit" className="w-full">Login</Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default AdminLogin;
+


### PR DESCRIPTION
## Summary
- implement simple admin auth context verifying fixed credentials
- add admin login and dashboard pages protected by AdminRoute
- wire admin routes into app

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 71 problems (55 errors, 16 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_6898d871c5dc832ebdeaecdd92f2abed