### PR TITLE
feat: add job and karma creation forms

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,154 @@
+const openModalBtn = document.getElementById('open-modal');
+const modeModal = document.getElementById('mode-modal');
+const jobModeBtn = document.getElementById('job-mode');
+const karmaModeBtn = document.getElementById('karma-mode');
+const closeModalBtn = document.getElementById('close-modal');
+const jobForm = document.getElementById('job-form');
+const karmaForm = document.getElementById('karma-form');
+const jobBackBtn = document.getElementById('job-back');
+const karmaBackBtn = document.getElementById('karma-back');
+
+function showModal() {
+  modeModal.classList.remove('hidden');
+  openModalBtn.setAttribute('aria-expanded', 'true');
+}
+function hideModal() {
+  modeModal.classList.add('hidden');
+  openModalBtn.setAttribute('aria-expanded', 'false');
+}
+openModalBtn.addEventListener('click', showModal);
+closeModalBtn.addEventListener('click', hideModal);
+
+jobModeBtn.addEventListener('click', () => {
+  hideModal();
+  jobForm.classList.remove('hidden');
+});
+karmaModeBtn.addEventListener('click', () => {
+  hideModal();
+  karmaForm.classList.remove('hidden');
+});
+
+jobBackBtn.addEventListener('click', () => {
+  jobForm.reset();
+  clearPreview('job');
+  jobForm.classList.add('hidden');
+  showModal();
+});
+karmaBackBtn.addEventListener('click', () => {
+  karmaForm.reset();
+  clearPreview('karma');
+  karmaForm.classList.add('hidden');
+  showModal();
+});
+
+function clearPreview(prefix) {
+  const img = document.getElementById(`${prefix}-preview`);
+  if (img) {
+    img.src = '';
+    img.classList.add('hidden');
+  }
+}
+
+function setupImagePreview(inputId, imgId) {
+  const input = document.getElementById(inputId);
+  const img = document.getElementById(imgId);
+  const error = input.nextElementSibling; // the <p> after input
+  input.addEventListener('change', () => {
+    const file = input.files[0];
+    if (!file) return;
+    if (!['image/jpeg', 'image/png'].includes(file.type)) {
+      error.textContent = 'Nur JPEG oder PNG erlaubt';
+      error.classList.remove('hidden');
+      input.value = '';
+      img.classList.add('hidden');
+      return;
+    }
+    if (file.size > 5 * 1024 * 1024) {
+      error.textContent = 'Datei darf maximal 5 MB sein';
+      error.classList.remove('hidden');
+      input.value = '';
+      img.classList.add('hidden');
+      return;
+    }
+    error.textContent = '';
+    error.classList.add('hidden');
+    const reader = new FileReader();
+    reader.onload = e => {
+      img.src = e.target.result;
+      img.classList.remove('hidden');
+    };
+    reader.readAsDataURL(file);
+  });
+}
+
+setupImagePreview('job-photo', 'job-preview');
+setupImagePreview('karma-photo', 'karma-preview');
+
+function validateForm(form) {
+  let valid = true;
+  const fields = form.querySelectorAll('input[required], textarea[required], select[required]');
+  fields.forEach(field => {
+    const error = field.nextElementSibling;
+    if (!field.checkValidity()) {
+      error.textContent = field.validationMessage;
+      error.classList.remove('hidden');
+      valid = false;
+    } else {
+      error.textContent = '';
+      error.classList.add('hidden');
+    }
+  });
+  const fileInput = form.querySelector('input[type="file"]');
+  const fileError = fileInput.nextElementSibling;
+  if (fileInput.files.length === 0) {
+    fileError.textContent = 'Bitte laden Sie ein Bild hoch';
+    fileError.classList.remove('hidden');
+    valid = false;
+  }
+  return valid;
+}
+
+jobForm.addEventListener('submit', e => {
+  e.preventDefault();
+  if (!validateForm(jobForm)) return;
+  const data = {
+    mode: 'job',
+    title: document.getElementById('job-title').value,
+    description: document.getElementById('job-description').value,
+    amount: Number(document.getElementById('job-amount').value),
+    timer: Number(document.getElementById('job-timer').value),
+    category: document.getElementById('job-category').value,
+  };
+  console.log(data);
+  jobForm.reset();
+  clearPreview('job');
+  jobForm.classList.add('hidden');
+  showModal();
+});
+
+karmaForm.addEventListener('submit', e => {
+  e.preventDefault();
+  if (!validateForm(karmaForm)) return;
+  const data = {
+    mode: 'karma',
+    title: document.getElementById('karma-title').value,
+    description: document.getElementById('karma-description').value,
+    amount: Number(document.getElementById('karma-amount').value),
+    timer: Number(document.getElementById('karma-timer').value),
+    karmaPoints: Number(document.getElementById('karma-points').value),
+  };
+  console.log(data);
+  karmaForm.reset();
+  clearPreview('karma');
+  karmaForm.classList.add('hidden');
+  showModal();
+});
+
+// Keyboard accessibility: close modal with Escape
+window.addEventListener('keydown', e => {
+  if (e.key === 'Escape') {
+    if (!modeModal.classList.contains('hidden')) hideModal();
+    if (!jobForm.classList.contains('hidden')) jobBackBtn.click();
+    if (!karmaForm.classList.contains('hidden')) karmaBackBtn.click();
+  }
+});

--- a/index.html
+++ b/index.html
@@ -1,24 +1,111 @@
 <!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>refine-project-board</title>
-    <meta name="description" content="Lovable Generated Project" />
-    <meta name="author" content="Lovable" />
+<html lang="de">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Job oder Karma erstellen</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 min-h-screen flex items-center justify-center p-4">
+  <button id="open-modal" aria-label="Job erstellen" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400">Job erstellen</button>
 
-    <meta property="og:title" content="refine-project-board" />
-    <meta property="og:description" content="Lovable Generated Project" />
-    <meta property="og:type" content="website" />
-    <meta property="og:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
+  <!-- Auswahl-Modal -->
+  <div id="mode-modal" class="hidden fixed inset-0 z-10 flex items-center justify-center bg-black bg-opacity-50" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+    <div class="bg-white rounded-lg p-6 w-11/12 max-w-sm">
+      <h2 id="modal-title" class="text-xl font-semibold mb-4 text-center">Modus wählen</h2>
+      <div class="flex flex-col gap-2">
+        <button id="job-mode" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400">Job-Modus</button>
+        <button id="karma-mode" class="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-400">Karma-Modus</button>
+        <button id="close-modal" class="px-4 py-2 bg-gray-300 text-gray-700 rounded hover:bg-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-400">Abbrechen</button>
+      </div>
+    </div>
+  </div>
 
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:site" content="@lovable_dev" />
-    <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
-  </head>
+  <!-- Job-Formular -->
+  <form id="job-form" class="hidden w-full max-w-lg mx-auto bg-white p-6 rounded-lg shadow-md space-y-4" aria-labelledby="job-form-title">
+    <h2 id="job-form-title" class="text-2xl font-bold mb-4">Job-Modus</h2>
+    <div>
+      <label for="job-title" class="block mb-1">Titel</label>
+      <input id="job-title" type="text" maxlength="100" required class="w-full border rounded p-2" />
+      <p class="text-red-500 text-sm mt-1 hidden"></p>
+    </div>
+    <div>
+      <label for="job-description" class="block mb-1">Beschreibung</label>
+      <textarea id="job-description" maxlength="1000" required class="w-full border rounded p-2"></textarea>
+      <p class="text-red-500 text-sm mt-1 hidden"></p>
+    </div>
+    <div>
+      <label for="job-amount" class="block mb-1">Betrag</label>
+      <input id="job-amount" type="number" min="1" required class="w-full border rounded p-2" />
+      <p class="text-red-500 text-sm mt-1 hidden"></p>
+    </div>
+    <div>
+      <label for="job-timer" class="block mb-1">Timer (in Stunden)</label>
+      <input id="job-timer" type="number" min="1" required class="w-full border rounded p-2" />
+      <p class="text-red-500 text-sm mt-1 hidden"></p>
+    </div>
+    <div>
+      <label for="job-category" class="block mb-1">Kategorie</label>
+      <select id="job-category" required class="w-full border rounded p-2">
+        <option value="">Bitte wählen</option>
+        <option>Haushalt</option>
+        <option>Transport</option>
+        <option>Reparatur</option>
+      </select>
+      <p class="text-red-500 text-sm mt-1 hidden"></p>
+    </div>
+    <div>
+      <label for="job-photo" class="block mb-1">Foto-Upload</label>
+      <input id="job-photo" type="file" accept="image/jpeg,image/png" required class="w-full border rounded p-2" />
+      <p class="text-red-500 text-sm mt-1 hidden"></p>
+      <img id="job-preview" alt="Vorschau" class="mt-2 max-h-48 hidden" />
+    </div>
+    <div class="flex gap-2">
+      <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 focus:ring-2 focus:ring-blue-400">Erstellen</button>
+      <button type="button" id="job-back" class="px-4 py-2 bg-gray-300 text-gray-700 rounded hover:bg-gray-400 focus:ring-2 focus:ring-gray-400">Zurück</button>
+    </div>
+  </form>
 
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
-  </body>
+  <!-- Karma-Formular -->
+  <form id="karma-form" class="hidden w-full max-w-lg mx-auto bg-white p-6 rounded-lg shadow-md space-y-4" aria-labelledby="karma-form-title">
+    <h2 id="karma-form-title" class="text-2xl font-bold mb-4">Karma-Modus</h2>
+    <div>
+      <label for="karma-title" class="block mb-1">Titel</label>
+      <input id="karma-title" type="text" maxlength="100" required class="w-full border rounded p-2" />
+      <p class="text-red-500 text-sm mt-1 hidden"></p>
+    </div>
+    <div>
+      <label for="karma-description" class="block mb-1">Beschreibung</label>
+      <textarea id="karma-description" maxlength="1000" required class="w-full border rounded p-2"></textarea>
+      <p class="text-red-500 text-sm mt-1 hidden"></p>
+    </div>
+    <div>
+      <label for="karma-amount" class="block mb-1">Betrag</label>
+      <input id="karma-amount" type="number" min="1" required class="w-full border rounded p-2" />
+      <p class="text-red-500 text-sm mt-1 hidden"></p>
+    </div>
+    <div>
+      <label for="karma-timer" class="block mb-1">Timer (in Stunden)</label>
+      <input id="karma-timer" type="number" min="1" required class="w-full border rounded p-2" />
+      <p class="text-red-500 text-sm mt-1 hidden"></p>
+    </div>
+    <div>
+      <label for="karma-points" class="block mb-1">Karma-Punkte</label>
+      <input id="karma-points" type="number" min="1" required class="w-full border rounded p-2" />
+      <p class="text-red-500 text-sm mt-1 hidden"></p>
+    </div>
+    <div>
+      <label for="karma-photo" class="block mb-1">Foto-Upload</label>
+      <input id="karma-photo" type="file" accept="image/jpeg,image/png" required class="w-full border rounded p-2" />
+      <p class="text-red-500 text-sm mt-1 hidden"></p>
+      <img id="karma-preview" alt="Vorschau" class="mt-2 max-h-48 hidden" />
+    </div>
+    <div class="flex gap-2">
+      <button type="submit" class="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700 focus:ring-2 focus:ring-green-400">Erstellen</button>
+      <button type="button" id="karma-back" class="px-4 py-2 bg-gray-300 text-gray-700 rounded hover:bg-gray-400 focus:ring-2 focus:ring-gray-400">Zurück</button>
+    </div>
+  </form>
+
+  <script src="app.js"></script>
+</body>
 </html>


### PR DESCRIPTION
## Summary
- add modal allowing choice between job and karma posting modes
- include job/karma forms with validation, timer, and image preview

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: lint errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_6898dcc88b40832eb9df02ed1c9d827b