### PR TITLE
Refine profile tabs layout

### DIFF
--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -79,11 +79,6 @@ const Profile = () => {
     }
   ];
 
-  const favorites = [
-    { id: 1, name: 'Maria S.', type: 'Auftraggeber', jobs: 3, rating: 4.9 },
-    { id: 2, name: 'Thomas M.', type: 'Auftraggeber', jobs: 2, rating: 4.7 },
-  ];
-
   const handleSave = () => {
     console.log('Profil gespeichert:', profileData);
     setIsEditing(false);
@@ -286,12 +281,10 @@ const Profile = () => {
           {/* Right Column - Tabs */}
           <div className="lg:col-span-2">
             <Tabs defaultValue="jobs" className="w-full">
-              <TabsList className="grid w-full grid-cols-5 bg-gray-800 border-gray-700">
+              <TabsList className="grid w-full grid-cols-3 gap-2 bg-gray-800 border-gray-700">
                 <TabsTrigger value="jobs" className="text-gray-300">Jobs</TabsTrigger>
                 <TabsTrigger value="achievements" className="text-gray-300">Erfolge</TabsTrigger>
                 <TabsTrigger value="reviews" className="text-gray-300">Bewertungen</TabsTrigger>
-                <TabsTrigger value="favorites" className="text-gray-300">Favoriten</TabsTrigger>
-                <TabsTrigger value="verification" className="text-gray-300">Verifizierung</TabsTrigger>
               </TabsList>
 
               <TabsContent value="jobs" className="space-y-4">
@@ -339,11 +332,11 @@ const Profile = () => {
                   <CardContent>
                     <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                       {achievements.map((achievement) => (
-                        <div 
+                        <div
                           key={achievement.id}
                           className={`p-4 rounded-lg border ${
-                            achievement.earned 
-                              ? 'bg-gray-700 border-yellow-600' 
+                            achievement.earned
+                              ? 'bg-gray-700 border-yellow-600'
                               : 'bg-gray-800 border-gray-600 opacity-50'
                           }`}
                         >
@@ -387,142 +380,112 @@ const Profile = () => {
                 </Card>
               </TabsContent>
 
-              <TabsContent value="favorites" className="space-y-4">
-                <Card className="bg-gray-800 border-gray-700">
-                  <CardHeader>
-                    <CardTitle className="text-white">Favoriten</CardTitle>
-                  </CardHeader>
-                  <CardContent className="space-y-4">
-                    {favorites.map((favorite) => (
-                      <div key={favorite.id} className="p-4 bg-gray-700 rounded-lg">
-                        <div className="flex justify-between items-center">
-                          <div>
-                            <h4 className="text-white font-medium">{favorite.name}</h4>
-                            <p className="text-gray-400 text-sm">{favorite.type} • {favorite.jobs} Jobs</p>
-                          </div>
-                          <div className="text-right">
-                            <div className="flex items-center text-yellow-400 mb-1">
-                              <Star className="w-4 h-4 fill-current mr-1" />
-                              <span>{favorite.rating}</span>
-                            </div>
-                            <Button size="sm" variant="outline" className="border-gray-600 text-gray-300">
-                              Entfernen
-                            </Button>
-                          </div>
-                        </div>
-                      </div>
-                    ))}
-                  </CardContent>
-                </Card>
-              </TabsContent>
-
-              <TabsContent value="verification" className="space-y-4">
-                <Card className="bg-gray-800 border-gray-700">
-                  <CardHeader>
-                    <CardTitle className="text-white flex items-center">
-                      <Shield className="w-5 h-5 mr-2" />
-                      Verifizierung
-                    </CardTitle>
-                    <p className="text-gray-400 text-sm">
-                      Verifizieren Sie Ihre Daten, um Vertrauen zu schaffen und höhere Limits zu erhalten.
-                    </p>
-                  </CardHeader>
-                  <CardContent className="space-y-6">
-                    {/* Telefon-Verifizierung */}
-                    <div className="p-4 bg-gray-700 rounded-lg">
-                      <div className="flex items-center justify-between mb-3">
-                        <div className="flex items-center">
-                          <Phone className="w-5 h-5 text-blue-400 mr-2" />
-                          <h3 className="text-white font-medium">Telefonnummer</h3>
-                        </div>
-                        {verificationData.phoneVerified ? (
-                          <div className="flex items-center text-green-400">
-                            <CheckCircle className="w-5 h-5 mr-1" />
-                            <span className="text-sm">Verifiziert</span>
-                          </div>
-                        ) : (
-                          <div className="flex items-center text-orange-400">
-                            <AlertCircle className="w-5 h-5 mr-1" />
-                            <span className="text-sm">Nicht verifiziert</span>
-                          </div>
-                        )}
-                      </div>
-                      <p className="text-gray-400 text-sm mb-3">
-                        Verifizieren Sie Ihre Telefonnummer, um SMS-Benachrichtigungen zu erhalten.
-                      </p>
-                      <div className="flex gap-2">
-                        <Input
-                          value={verificationData.phoneNumber}
-                          onChange={(e) => handleVerificationChange('phoneNumber', e.target.value)}
-                          placeholder="Telefonnummer"
-                          className="bg-gray-600 border-gray-500 text-white"
-                          disabled={verificationData.phoneVerified}
-                        />
-                        <Button 
-                          onClick={handlePhoneVerification}
-                          disabled={verificationData.phoneVerified}
-                          className="bg-blue-600 hover:bg-blue-700"
-                        >
-                          {verificationData.phoneVerified ? 'Verifiziert' : 'Verifizieren'}
-                        </Button>
-                      </div>
-                    </div>
-
-                    {/* Bank-Verifizierung */}
-                    <div className="p-4 bg-gray-700 rounded-lg">
-                      <div className="flex items-center justify-between mb-3">
-                        <div className="flex items-center">
-                          <CreditCard className="w-5 h-5 text-green-400 mr-2" />
-                          <h3 className="text-white font-medium">Bankkonto</h3>
-                        </div>
-                        {verificationData.bankAccountVerified ? (
-                          <div className="flex items-center text-green-400">
-                            <CheckCircle className="w-5 h-5 mr-1" />
-                            <span className="text-sm">Verifiziert</span>
-                          </div>
-                        ) : (
-                          <div className="flex items-center text-orange-400">
-                            <AlertCircle className="w-5 h-5 mr-1" />
-                            <span className="text-sm">Nicht verifiziert</span>
-                          </div>
-                        )}
-                      </div>
-                      <p className="text-gray-400 text-sm mb-3">
-                        Verifizieren Sie Ihr Bankkonto für sichere Zahlungen und höhere Limits.
-                      </p>
-                      <div className="flex gap-2">
-                        <Input
-                          value={verificationData.bankAccount}
-                          onChange={(e) => handleVerificationChange('bankAccount', e.target.value)}
-                          placeholder="IBAN (DE12 3456 7890 1234 5678 90)"
-                          className="bg-gray-600 border-gray-500 text-white"
-                          disabled={verificationData.bankAccountVerified}
-                        />
-                        <Button 
-                          onClick={handleBankVerification}
-                          disabled={verificationData.bankAccountVerified || !verificationData.bankAccount}
-                          className="bg-green-600 hover:bg-green-700"
-                        >
-                          {verificationData.bankAccountVerified ? 'Verifiziert' : 'Verifizieren'}
-                        </Button>
-                      </div>
-                    </div>
-
-                    {/* Verifizierungs-Vorteile */}
-                    <div className="p-4 bg-blue-900/20 border border-blue-800 rounded-lg">
-                      <h3 className="text-white font-medium mb-2">Vorteile der Verifizierung</h3>
-                      <ul className="text-gray-400 text-sm space-y-1">
-                        <li>• Höhere Vertrauenswürdigkeit bei anderen Nutzern</li>
-                        <li>• Höhere Limits für Transaktionen</li>
-                        <li>• Schnellere Zahlungsabwicklung</li>
-                        <li>• Zugang zu Premium-Features</li>
-                        <li>• Bevorzugte Behandlung bei Bewerbungen</li>
-                      </ul>
-                    </div>
-                  </CardContent>
-                </Card>
-              </TabsContent>
             </Tabs>
+
+            <Card className="bg-gray-800 border-gray-700 mt-6">
+              <CardHeader>
+                <CardTitle className="text-white flex items-center">
+                  <Shield className="w-5 h-5 mr-2" />
+                  Verifizierung
+                </CardTitle>
+                <p className="text-gray-400 text-sm">
+                  Verifizieren Sie Ihre Daten, um Vertrauen zu schaffen und höhere Limits zu erhalten.
+                </p>
+              </CardHeader>
+              <CardContent className="space-y-6">
+                {/* Telefon-Verifizierung */}
+                <div className="p-4 bg-gray-700 rounded-lg">
+                  <div className="flex items-center justify-between mb-3">
+                    <div className="flex items-center">
+                      <Phone className="w-5 h-5 text-blue-400 mr-2" />
+                      <h3 className="text-white font-medium">Telefonnummer</h3>
+                    </div>
+                    {verificationData.phoneVerified ? (
+                      <div className="flex items-center text-green-400">
+                        <CheckCircle className="w-5 h-5 mr-1" />
+                        <span className="text-sm">Verifiziert</span>
+                      </div>
+                    ) : (
+                      <div className="flex items-center text-orange-400">
+                        <AlertCircle className="w-5 h-5 mr-1" />
+                        <span className="text-sm">Nicht verifiziert</span>
+                      </div>
+                    )}
+                  </div>
+                  <p className="text-gray-400 text-sm mb-3">
+                    Verifizieren Sie Ihre Telefonnummer, um SMS-Benachrichtigungen zu erhalten.
+                  </p>
+                  <div className="flex gap-2">
+                    <Input
+                      value={verificationData.phoneNumber}
+                      onChange={(e) => handleVerificationChange('phoneNumber', e.target.value)}
+                      placeholder="Telefonnummer"
+                      className="bg-gray-600 border-gray-500 text-white"
+                      disabled={verificationData.phoneVerified}
+                    />
+                    <Button
+                      onClick={handlePhoneVerification}
+                      disabled={verificationData.phoneVerified}
+                      className="bg-blue-600 hover:bg-blue-700"
+                    >
+                      {verificationData.phoneVerified ? 'Verifiziert' : 'Verifizieren'}
+                    </Button>
+                  </div>
+                </div>
+
+                {/* Bank-Verifizierung */}
+                <div className="p-4 bg-gray-700 rounded-lg">
+                  <div className="flex items-center justify-between mb-3">
+                    <div className="flex items-center">
+                      <CreditCard className="w-5 h-5 text-green-400 mr-2" />
+                      <h3 className="text-white font-medium">Bankkonto</h3>
+                    </div>
+                    {verificationData.bankAccountVerified ? (
+                      <div className="flex items-center text-green-400">
+                        <CheckCircle className="w-5 h-5 mr-1" />
+                        <span className="text-sm">Verifiziert</span>
+                      </div>
+                    ) : (
+                      <div className="flex items-center text-orange-400">
+                        <AlertCircle className="w-5 h-5 mr-1" />
+                        <span className="text-sm">Nicht verifiziert</span>
+                      </div>
+                    )}
+                  </div>
+                  <p className="text-gray-400 text-sm mb-3">
+                    Verifizieren Sie Ihr Bankkonto für sichere Zahlungen und höhere Limits.
+                  </p>
+                  <div className="flex gap-2">
+                    <Input
+                      value={verificationData.bankAccount}
+                      onChange={(e) => handleVerificationChange('bankAccount', e.target.value)}
+                      placeholder="IBAN (DE12 3456 7890 1234 5678 90)"
+                      className="bg-gray-600 border-gray-500 text-white"
+                      disabled={verificationData.bankAccountVerified}
+                    />
+                    <Button
+                      onClick={handleBankVerification}
+                      disabled={verificationData.bankAccountVerified || !verificationData.bankAccount}
+                      className="bg-green-600 hover:bg-green-700"
+                    >
+                      {verificationData.bankAccountVerified ? 'Verifiziert' : 'Verifizieren'}
+                    </Button>
+                  </div>
+                </div>
+
+                {/* Verifizierungs-Vorteile */}
+                <div className="p-4 bg-blue-900/20 border border-blue-800 rounded-lg">
+                  <h3 className="text-white font-medium mb-2">Vorteile der Verifizierung</h3>
+                  <ul className="text-gray-400 text-sm space-y-1">
+                    <li>• Höhere Vertrauenswürdigkeit bei anderen Nutzern</li>
+                    <li>• Höhere Limits für Transaktionen</li>
+                    <li>• Schnellere Zahlungsabwicklung</li>
+                    <li>• Zugang zu Premium-Features</li>
+                    <li>• Bevorzugte Behandlung bei Bewerbungen</li>
+                  </ul>
+                </div>
+              </CardContent>
+            </Card>
           </div>
         </div>
       </main>


### PR DESCRIPTION
## Summary
- Remove Favoriten tab and its data from profile
- Keep Jobs, Erfolge, Bewertungen as tabs with spacing
- Move verification into its own section below the tabs

## Testing
- `npm run lint` *(fails: React hook missing dependency, Unexpected any, require style import)*

------
https://chatgpt.com/codex/tasks/task_e_6898ddf17dc0832eac60da11a57c1f91