### PR TITLE
feat: add job creation form and supabase integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,20 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## Environment variables
+
+Create a `.env.local` file and provide the following keys:
+
+```
+VITE_SUPABASE_URL=
+VITE_SUPABASE_ANON_KEY=
+VITE_STRIPE_SECRET_KEY=
+```
+
+## Job creation form
+
+A basic job creation form is available at `/jobs/new`. It validates input with Zod and stores new jobs in Supabase.
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/b62ad899-1b92-4bec-89ed-c9511234a672) and click on Share -> Publish.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
-    "server": "node server/index.js"
+    "server": "node server/index.js",
+    "test": "node --test"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import Dashboard from "./pages/Dashboard";
 import Auth from "./pages/Auth";
 import Map from "./pages/Map";
 import Jobs from "./pages/Jobs";
+import NewJob from "./pages/NewJob";
 import Profile from "./pages/Profile";
 import Invite from "./pages/Invite";
 import Wallet from "./pages/Wallet";
@@ -60,6 +61,11 @@ const App = () => (
               <Route path="/jobs" element={
                 <ProtectedRoute>
                   <Jobs />
+                </ProtectedRoute>
+              } />
+              <Route path="/jobs/new" element={
+                <ProtectedRoute>
+                  <NewJob />
                 </ProtectedRoute>
               } />
               <Route path="/profile" element={

--- a/src/components/JobTimer.tsx
+++ b/src/components/JobTimer.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+
+interface JobTimerProps {
+  deadline: Date;
+}
+
+export function JobTimer({ deadline }: JobTimerProps) {
+  const [remaining, setRemaining] = useState(() => deadline.getTime() - Date.now());
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setRemaining(deadline.getTime() - Date.now());
+    }, 1000);
+    return () => clearInterval(id);
+  }, [deadline]);
+
+  if (remaining <= 0) {
+    return <span className="text-red-600" role="status">Expired</span>;
+  }
+
+  const seconds = Math.floor((remaining / 1000) % 60);
+  const minutes = Math.floor((remaining / 1000 / 60) % 60);
+  const hours = Math.floor(remaining / 1000 / 60 / 60);
+
+  const pad = (n: number) => n.toString().padStart(2, '0');
+
+  return (
+    <span aria-label="time remaining">
+      {pad(hours)}:{pad(minutes)}:{pad(seconds)}
+    </span>
+  );
+}
+
+export default JobTimer;

--- a/src/components/forms/JobForm.tsx
+++ b/src/components/forms/JobForm.tsx
@@ -1,0 +1,133 @@
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import supabase from '@/lib/supabaseClient';
+import { useNavigate } from 'react-router-dom';
+import { useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { toast } from 'sonner';
+
+export const jobSchema = z.object({
+  title: z.string().min(5).max(100),
+  description: z.string().min(20),
+  mode: z.enum(['goodDeeds', 'paid']),
+  price: z.preprocess((val) => (val === '' ? undefined : Number(val)), z.number().positive().optional()),
+  category: z.string().min(1),
+  latitude: z.preprocess((val) => Number(val), z.number()),
+  longitude: z.preprocess((val) => Number(val), z.number()),
+  timeLimit: z.preprocess((val) => (val === '' ? undefined : Number(val)), z.number().int().positive().optional()),
+  deadline: z.preprocess((val) => (val ? new Date(val) : undefined), z.date().optional()),
+}).superRefine((data, ctx) => {
+  if (data.mode === 'paid' && typeof data.price !== 'number') {
+    ctx.addIssue({ code: 'custom', path: ['price'], message: 'Price required for paid jobs' });
+  }
+  if (!data.timeLimit && !data.deadline) {
+    ctx.addIssue({ code: 'custom', path: ['timeLimit'], message: 'Provide time limit or deadline' });
+  }
+});
+
+export type JobFormValues = z.infer<typeof jobSchema>;
+
+export function JobForm() {
+  const navigate = useNavigate();
+  const [loading, setLoading] = useState(false);
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors },
+  } = useForm<JobFormValues>({ resolver: zodResolver(jobSchema), defaultValues: { mode: 'goodDeeds' } });
+
+  const mode = watch('mode');
+
+  const onSubmit = async (values: JobFormValues) => {
+    setLoading(true);
+    const deadline = values.deadline ?? new Date(Date.now() + (values.timeLimit || 0) * 60000);
+    const { data, error } = await supabase
+      .from('jobs')
+      .insert({
+        title: values.title,
+        description: values.description,
+        mode: values.mode,
+        price: values.mode === 'paid' ? values.price : null,
+        category: values.category,
+        location: `POINT(${values.longitude} ${values.latitude})`,
+        deadline: deadline.toISOString(),
+        status: 'open',
+      })
+      .select()
+      .single();
+
+    setLoading(false);
+    if (error) {
+      toast.error(error.message);
+    } else {
+      toast.success('Job created');
+      navigate(`/jobs/${data.id}`);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+      <div>
+        <Label htmlFor="title">Title</Label>
+        <Input id="title" {...register('title')} />
+        {errors.title && <p className="text-sm text-red-500">{errors.title.message}</p>}
+      </div>
+      <div>
+        <Label htmlFor="description">Description</Label>
+        <Textarea id="description" {...register('description')} />
+        {errors.description && <p className="text-sm text-red-500">{errors.description.message}</p>}
+      </div>
+      <div>
+        <Label htmlFor="mode">Mode</Label>
+        <select id="mode" className="border p-2 w-full" {...register('mode')} defaultValue={mode}>
+          <option value="goodDeeds">Good Deeds</option>
+          <option value="paid">Paid</option>
+        </select>
+      </div>
+      {mode === 'paid' && (
+        <div>
+          <Label htmlFor="price">Price</Label>
+          <Input id="price" type="number" step="0.01" {...register('price')} />
+          {errors.price && <p className="text-sm text-red-500">{errors.price.message}</p>}
+        </div>
+      )}
+      <div>
+        <Label htmlFor="category">Category</Label>
+        <Input id="category" {...register('category')} />
+        {errors.category && <p className="text-sm text-red-500">{errors.category.message}</p>}
+      </div>
+      <div className="flex space-x-2">
+        <div className="flex-1">
+          <Label htmlFor="latitude">Latitude</Label>
+          <Input id="latitude" type="number" step="any" {...register('latitude')} />
+          {errors.latitude && <p className="text-sm text-red-500">{errors.latitude.message}</p>}
+        </div>
+        <div className="flex-1">
+          <Label htmlFor="longitude">Longitude</Label>
+          <Input id="longitude" type="number" step="any" {...register('longitude')} />
+          {errors.longitude && <p className="text-sm text-red-500">{errors.longitude.message}</p>}
+        </div>
+      </div>
+      <div>
+        <Label htmlFor="timeLimit">Time Limit (minutes)</Label>
+        <Input id="timeLimit" type="number" {...register('timeLimit')} />
+        {errors.timeLimit && <p className="text-sm text-red-500">{errors.timeLimit.message}</p>}
+      </div>
+      <div>
+        <Label htmlFor="deadline">Deadline</Label>
+        <Input id="deadline" type="datetime-local" {...register('deadline')} />
+        {errors.deadline && <p className="text-sm text-red-500">{errors.deadline.message}</p>}
+      </div>
+      <Button type="submit" disabled={loading}>
+        {loading ? 'Saving...' : 'Create Job'}
+      </Button>
+    </form>
+  );
+}
+
+export default JobForm;

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,0 +1,23 @@
+export interface NotificationPayload {
+  event_type: string;
+  recipient_id: string;
+  data?: Record<string, unknown>;
+}
+
+/**
+ * Sends notification via Supabase edge function.
+ */
+export async function sendNotification(payload: NotificationPayload) {
+  try {
+    const res = await fetch('/functions/v1/send-notification', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) {
+      console.error('Failed to send notification', await res.text());
+    }
+  } catch (err) {
+    console.error('Notification error', err);
+  }
+}

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -1,0 +1,11 @@
+import Stripe from 'stripe';
+
+const key = import.meta.env.VITE_STRIPE_SECRET_KEY as string;
+
+if (!key) {
+  console.warn('Stripe secret key missing');
+}
+
+export const stripe = new Stripe(key || '', { apiVersion: '2022-11-15' });
+
+export default stripe;

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,0 +1,12 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  console.warn('Supabase environment variables are missing');
+}
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+
+export default supabase;

--- a/src/pages/NewJob.tsx
+++ b/src/pages/NewJob.tsx
@@ -1,0 +1,10 @@
+import JobForm from '@/components/forms/JobForm';
+
+export default function NewJob() {
+  return (
+    <div className="p-4 max-w-2xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Create Job</h1>
+      <JobForm />
+    </div>
+  );
+}

--- a/supabase/migrations/20250815120000_add_jobs_table.sql
+++ b/supabase/migrations/20250815120000_add_jobs_table.sql
@@ -1,0 +1,17 @@
+create table if not exists jobs (
+  id uuid primary key default uuid_generate_v4(),
+  user_id uuid references profiles(user_id) not null,
+  title varchar(100) not null,
+  description text not null,
+  mode varchar(20) not null check (mode in ('goodDeeds','paid')),
+  price numeric(10,2),
+  category varchar(50),
+  location geography(point),
+  status varchar(20) default 'open' check (status in ('open','in_progress','completed','canceled')),
+  deadline timestamptz,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+create index if not exists idx_jobs_user on jobs(user_id);
+create index if not exists idx_jobs_status on jobs(status);

--- a/tests/jobSchema.test.js
+++ b/tests/jobSchema.test.js
@@ -1,0 +1,36 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { z } from 'zod';
+
+const schema = z.object({
+  title: z.string().min(5).max(100),
+  description: z.string().min(20),
+  mode: z.enum(['goodDeeds', 'paid']),
+  price: z.number().positive().optional(),
+  category: z.string().min(1),
+  latitude: z.number(),
+  longitude: z.number(),
+  timeLimit: z.number().int().positive().optional(),
+  deadline: z.date().optional(),
+}).superRefine((data, ctx) => {
+  if (data.mode === 'paid' && typeof data.price !== 'number') {
+    ctx.addIssue({ code: 'custom', path: ['price'], message: 'Price required for paid jobs' });
+  }
+  if (!data.timeLimit && !data.deadline) {
+    ctx.addIssue({ code: 'custom', path: ['timeLimit'], message: 'Provide time limit or deadline' });
+  }
+});
+
+test('paid jobs require price', () => {
+  const res = schema.safeParse({
+    title: 'hello world',
+    description: 'a'.repeat(20),
+    mode: 'paid',
+    category: 'cat',
+    latitude: 1,
+    longitude: 1,
+    timeLimit: 30,
+  });
+  assert.ok(!res.success);
+});
+


### PR DESCRIPTION
## Summary
- scaffold Supabase client, Stripe helper and notification util
- add job creation form with Zod validation and timer component
- document env vars and add migration for jobs table

## Testing
- `npm run lint` (fails: Unexpected any, etc.)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689912e2512c832e9d492725e9926fc3