### PR TITLE
feat: scaffold notification system

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,30 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Notifications & E-Mail Setup
+
+The project ships with a basic notification service (push + mail). Required environment variables:
+
+```
+SUPABASE_URL=
+SUPABASE_ANON_KEY=
+SUPABASE_SERVICE_ROLE_KEY=
+ONESIGNAL_APP_ID=
+FCM_SERVER_KEY=
+APNS_KEYS_JSON=
+RESEND_API_KEY=
+SENDGRID_API_KEY=
+EMAIL_FROM="Mutuus <info@mutuus-app.de>"
+APP_BASE_URL=
+REDIS_URL=
+SIGNING_SECRET=
+EUROPE_TZ="Europe/Berlin"
+NOTIFY_RATE_LIMITS='{"perUserMinutes":10}'
+QUIET_HOURS_OVERRIDE_TYPES='["NEW_LOGIN","PAYMENT_ISSUE"]'
+```
+
+### DNS
+
+Configure SPF, DKIM and DMARC for `mutuus-app.de` so that emails from `info@mutuus-app.de` are accepted.
+

--- a/api/notifications/pixel/[img].js
+++ b/api/notifications/pixel/[img].js
@@ -1,0 +1,11 @@
+import { logger } from '../../../lib/logging.js';
+
+export default function handler(_req, res) {
+  logger.log('pixel-open');
+  const img = Buffer.from(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWNgYGBgAAAABQABDQottAAAAABJRU5ErkJggg==',
+    'base64'
+  );
+  res.setHeader('Content-Type', 'image/png');
+  res.end(img);
+}

--- a/api/notifications/redirect.js
+++ b/api/notifications/redirect.js
@@ -1,0 +1,8 @@
+import { logger } from '../../lib/logging.js';
+
+export default function handler(req, res) {
+  const { url } = req.query || {};
+  logger.log('redirect', req.query);
+  res.writeHead(302, { Location: url || '/' });
+  res.end();
+}

--- a/api/notifications/send.js
+++ b/api/notifications/send.js
@@ -1,0 +1,18 @@
+import { enqueue } from '../../lib/notify/queue.js';
+import { acquire } from '../../lib/notify/idempotency.js';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.statusCode = 405;
+    return res.end();
+  }
+  const { type, user_id, data = {}, priority = 'medium', dedupe_key } = req.body || {};
+  const key = dedupe_key || `${type}:${user_id}`;
+  if (!acquire(key)) {
+    res.statusCode = 202;
+    return res.end(JSON.stringify({ deduped: true }));
+  }
+  await enqueue({ type, userId: user_id, payload: data });
+  res.statusCode = 202;
+  res.end(JSON.stringify({ queued: true }));
+}

--- a/api/notifications/webhook.js
+++ b/api/notifications/webhook.js
@@ -1,0 +1,11 @@
+import { logger } from '../../lib/logging.js';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.statusCode = 405;
+    return res.end();
+  }
+  logger.log('webhook', req.body);
+  res.statusCode = 200;
+  res.end('ok');
+}

--- a/lib/i18n/de.json
+++ b/lib/i18n/de.json
@@ -1,0 +1,10 @@
+{
+  "JOB_ACCEPTED": "{{helper_name}} hat deinen Job „{{job_title}}“ angenommen. Chat jetzt öffnen.",
+  "NEW_APPLICATION": "{{count}} neue Bewerbungen für „{{job_title}}“.",
+  "JOB_REMINDER": "Erinnerung: „{{job_title}}“ startet in 1 Stunde.",
+  "PAYMENT_RELEASED": "{{amount}}€ für „{{job_title}}“ freigegeben. Jetzt auszahlen.",
+  "KARMA_UPDATE": "+{{points}} Karma! Level {{level}} erreicht.",
+  "NEARBY_JOB": "Neu: „{{job_title}}“ ({{distance_km}} km) – {{price}}€.",
+  "LEADERBOARD": "Du bist jetzt Platz {{rank}} in {{city}}.",
+  "VERIFICATION_SUCCESS": "Verifizierung abgeschlossen – Vollzugriff aktiv."
+}

--- a/lib/i18n/en.json
+++ b/lib/i18n/en.json
@@ -1,0 +1,10 @@
+{
+  "JOB_ACCEPTED": "{{helper_name}} accepted your job \"{{job_title}}\". Open chat now.",
+  "NEW_APPLICATION": "{{count}} new applications for \"{{job_title}}\".",
+  "JOB_REMINDER": "Reminder: \"{{job_title}}\" starts in 1 hour.",
+  "PAYMENT_RELEASED": "{{amount}}€ for \"{{job_title}}\" released. Withdraw now.",
+  "KARMA_UPDATE": "+{{points}} karma! Level {{level}} reached.",
+  "NEARBY_JOB": "New: \"{{job_title}}\" ({{distance_km}} km) – {{price}}€.",
+  "LEADERBOARD": "You are now rank {{rank}} in {{city}}.",
+  "VERIFICATION_SUCCESS": "Verification completed – full access granted."
+}

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -1,0 +1,9 @@
+export function log(...args) {
+  console.log(...args);
+}
+
+export function error(...args) {
+  console.error(...args);
+}
+
+export const logger = { log, error };

--- a/lib/notify/email.js
+++ b/lib/notify/email.js
@@ -1,0 +1,8 @@
+import { logger } from '../logging.js';
+
+const DEFAULT_FROM = process.env.EMAIL_FROM || 'Mutuus <info@mutuus-app.de>';
+
+export async function sendEmail(payload) {
+  const from = payload.from || DEFAULT_FROM;
+  logger.log('email', { ...payload, from });
+}

--- a/lib/notify/idempotency.js
+++ b/lib/notify/idempotency.js
@@ -1,0 +1,13 @@
+const map = new Map();
+
+export function acquire(key, ttlMs = 30 * 60 * 1000) {
+  const now = Date.now();
+  const exp = map.get(key);
+  if (exp && exp > now) return false;
+  map.set(key, now + ttlMs);
+  return true;
+}
+
+export function clear() {
+  map.clear();
+}

--- a/lib/notify/payloads.js
+++ b/lib/notify/payloads.js
@@ -1,0 +1,12 @@
+import de from '../i18n/de.json' assert { type: 'json' };
+import en from '../i18n/en.json' assert { type: 'json' };
+
+const translations = { de, en };
+
+export function buildMessage({ type, data, language = 'de' }) {
+  const template = (translations[language] && translations[language][type]) || translations.de[type] || '';
+  return template.replace(/{{(.*?)}}/g, (_, key) => {
+    const value = data[key.trim()];
+    return value !== undefined ? String(value) : '';
+  });
+}

--- a/lib/notify/push.js
+++ b/lib/notify/push.js
@@ -1,0 +1,5 @@
+import { logger } from '../logging.js';
+
+export async function sendPush(token, payload) {
+  logger.log('push', token, payload);
+}

--- a/lib/notify/queue.js
+++ b/lib/notify/queue.js
@@ -1,0 +1,5 @@
+import { logger } from '../logging.js';
+
+export async function enqueue(job) {
+  logger.log('queue:add', job);
+}

--- a/lib/notify/rules.js
+++ b/lib/notify/rules.js
@@ -1,0 +1,81 @@
+const rateMap = new Map();
+const dedupeMap = new Map();
+
+const TZ = process.env.EUROPE_TZ || 'Europe/Berlin';
+
+function minutesFromTime(t) {
+  const [h, m] = t.split(':').map(Number);
+  return h * 60 + m;
+}
+
+function getParts(date) {
+  const fmt = new Intl.DateTimeFormat('en-GB', {
+    timeZone: TZ,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+  const parts = fmt.formatToParts(date);
+  const obj = {};
+  for (const p of parts) obj[p.type] = parseInt(p.value, 10);
+  return obj;
+}
+
+function zoneOffset(date) {
+  return (new Date(date.toLocaleString('en-US', { timeZone: TZ })).getTime() - date.getTime()) / 60000;
+}
+
+export function inQuietHours(date, settings) {
+  const p = getParts(date);
+  const now = p.hour * 60 + p.minute;
+  const start = minutesFromTime(settings.quiet_hours_start);
+  const end = minutesFromTime(settings.quiet_hours_end);
+  if (start < end) {
+    return now >= start && now < end;
+  }
+  return now >= start || now < end;
+}
+
+export function nextSendTime(date, settings) {
+  const p = getParts(date);
+  const endMinutes = minutesFromTime(settings.quiet_hours_end);
+  const [endH, endM] = settings.quiet_hours_end.split(':').map(Number);
+  let day = p.day;
+  const now = p.hour * 60 + p.minute;
+  if (now >= endMinutes) day += 1;
+  const base = new Date(Date.UTC(p.year, p.month - 1, day, endH, endM));
+  const offset = zoneOffset(base);
+  const utc = base.getTime() - offset * 60000 + 30 * 60000;
+  return new Date(utc);
+}
+
+export function checkRateLimit(userId, priority, now = new Date(), limitMinutes = 10) {
+  if (priority === 'critical') return true;
+  const last = rateMap.get(userId) || 0;
+  const diff = now.getTime() - last;
+  if (diff >= limitMinutes * 60 * 1000) {
+    rateMap.set(userId, now.getTime());
+    return true;
+  }
+  return false;
+}
+
+export function resetRateLimit() {
+  rateMap.clear();
+}
+
+export function checkDedupe(key, now = Date.now(), ttlMs = 30 * 60 * 1000) {
+  const exp = dedupeMap.get(key);
+  if (exp && exp > now) {
+    return false;
+  }
+  dedupeMap.set(key, now + ttlMs);
+  return true;
+}
+
+export function resetDedupe() {
+  dedupeMap.clear();
+}

--- a/lib/notify/templates/register.html
+++ b/lib/notify/templates/register.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+  <body style="font-family:Arial,sans-serif;background:#fff;color:#000;">
+    <p>Willkommen bei Mutuus!</p>
+    <p>Bitte bestätige dein Konto.</p>
+    <p><a href="{{action_url}}">Jetzt bestätigen</a></p>
+    <hr>
+    <p style="font-size:12px;color:#666;">Mutuus, Adresse<br>
+    <a href="{{unsubscribe_url}}">Abmelden</a> |
+    <a href="{{prefs_url}}">Einstellungen</a></p>
+    <img src="{{pixel_url}}" width="1" height="1" alt="" />
+  </body>
+</html>

--- a/supabase/functions/chat-hook/index.ts
+++ b/supabase/functions/chat-hook/index.ts
@@ -1,0 +1,18 @@
+import { serve } from 'https://deno.land/std@0.224.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
+const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+const supabase = createClient(supabaseUrl, serviceKey);
+
+serve(async (req) => {
+  const { record } = await req.json();
+  // Trigger NEW_MESSAGE notification
+  await supabase.from('notification_events').insert({
+    user_id: record.recipient_id,
+    type: 'NEW_MESSAGE',
+    channel: 'push',
+    status: 'queued'
+  });
+  return new Response('ok');
+});

--- a/supabase/functions/notify/index.ts
+++ b/supabase/functions/notify/index.ts
@@ -1,0 +1,15 @@
+// Simplified Supabase Edge Function placeholder
+import { serve } from 'https://deno.land/std@0.224.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
+const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+const supabase = createClient(supabaseUrl, serviceKey);
+
+serve(async (req) => {
+  const body = await req.json();
+  // In production, load settings, apply rules, send via push/email
+  const { user_id, type } = body;
+  await supabase.from('notification_events').insert({ user_id, type, channel: 'inapp', status: 'queued' });
+  return new Response(JSON.stringify({ ok: true }), { headers: { 'Content-Type': 'application/json' } });
+});

--- a/supabase/functions/timer-hook/index.ts
+++ b/supabase/functions/timer-hook/index.ts
@@ -1,0 +1,17 @@
+import { serve } from 'https://deno.land/std@0.224.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
+const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+const supabase = createClient(supabaseUrl, serviceKey);
+
+serve(async (req) => {
+  const { record } = await req.json();
+  await supabase.from('notification_events').insert({
+    user_id: record.user_id,
+    type: 'JOB_REMINDER',
+    channel: 'push',
+    status: 'queued'
+  });
+  return new Response('ok');
+});

--- a/supabase/migrations/20250910120000_notifications.sql
+++ b/supabase/migrations/20250910120000_notifications.sql
@@ -1,0 +1,76 @@
+-- Notification system tables
+
+create table if not exists notification_settings (
+  user_id uuid primary key references profiles(user_id) on delete cascade,
+  job_updates boolean default true,
+  new_messages boolean default true,
+  karma_changes boolean default false,
+  promotions boolean default true,
+  weekly_digest boolean default true,
+  language text default 'de',
+  quiet_hours_start time default '22:00',
+  quiet_hours_end time default '07:00',
+  updated_at timestamptz default now()
+);
+
+create table if not exists device_tokens (
+  id bigserial primary key,
+  user_id uuid references profiles(user_id) on delete cascade,
+  provider text check (provider in ('onesignal','fcm','apns')),
+  token text not null,
+  platform text check (platform in ('ios','android','web')),
+  last_seen timestamptz default now(),
+  unique(user_id, token)
+);
+
+create table if not exists notification_events (
+  id bigserial primary key,
+  user_id uuid references profiles(user_id),
+  channel text check (channel in ('push','email','inapp')),
+  type text,
+  priority text check (priority in ('low','medium','high','critical')),
+  status text check (status in ('queued','sent','delivered','opened','clicked','bounced','failed','unsub')),
+  dedupe_key text,
+  meta jsonb,
+  created_at timestamptz default now()
+);
+create index if not exists idx_notif_user on notification_events(user_id);
+create index if not exists idx_notif_type on notification_events(type, channel);
+create index if not exists idx_notif_dedupe on notification_events(dedupe_key);
+
+create table if not exists email_events (
+  id bigserial primary key,
+  user_id uuid references profiles(user_id),
+  email_type text,
+  event text check (event in ('sent','opened','clicked','bounced','unsub')),
+  meta jsonb,
+  created_at timestamptz default now()
+);
+
+create table if not exists consent_log (
+  id bigserial primary key,
+  user_id uuid references profiles(user_id),
+  action text check (action in ('opt_in','opt_out','unsubscribed','dob_confirmed')),
+  channel text check (channel in ('email','push','sms','inapp')),
+  meta jsonb,
+  created_at timestamptz default now()
+);
+
+-- RLS
+alter table notification_settings enable row level security;
+create policy "select own settings" on notification_settings for select using (auth.uid() = user_id);
+create policy "update own settings" on notification_settings for update using (auth.uid() = user_id) with check (auth.uid() = user_id);
+
+alter table device_tokens enable row level security;
+create policy "select own tokens" on device_tokens for select using (auth.uid() = user_id);
+create policy "insert own tokens" on device_tokens for insert with check (auth.uid() = user_id);
+create policy "delete own tokens" on device_tokens for delete using (auth.uid() = user_id);
+
+alter table notification_events enable row level security;
+create policy "select own events" on notification_events for select using (auth.uid() = user_id);
+
+alter table email_events enable row level security;
+create policy "select own email events" on email_events for select using (auth.uid() = user_id);
+
+alter table consent_log enable row level security;
+create policy "select own consent" on consent_log for select using (auth.uid() = user_id);

--- a/tests/e2e/notifications.spec.js
+++ b/tests/e2e/notifications.spec.js
@@ -1,0 +1,24 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import sendHandler from '../../api/notifications/send.js';
+import { resetDedupe } from '../../lib/notify/rules.js';
+
+function mockRes() {
+  return {
+    statusCode: 0,
+    body: '',
+    end(data) { if (data) this.body = data; },
+    writeHead(code) { this.statusCode = code; },
+    setHeader() {},
+  };
+}
+
+test('send endpoint deduplicates second request', async () => {
+  resetDedupe();
+  const res1 = mockRes();
+  await sendHandler({ method: 'POST', body: { type: 'JOB_ACCEPTED', user_id: 'u1' } }, res1);
+  assert.ok(res1.body.includes('queued'));
+  const res2 = mockRes();
+  await sendHandler({ method: 'POST', body: { type: 'JOB_ACCEPTED', user_id: 'u1' } }, res2);
+  assert.ok(res2.body.includes('deduped'));
+});

--- a/tests/unit/notify.test.js
+++ b/tests/unit/notify.test.js
@@ -1,0 +1,39 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { inQuietHours, nextSendTime, checkRateLimit, resetRateLimit, checkDedupe, resetDedupe } from '../../lib/notify/rules.js';
+import { buildMessage } from '../../lib/notify/payloads.js';
+
+const settings = { quiet_hours_start: '22:00', quiet_hours_end: '07:00' };
+
+function date(str) { return new Date(str); }
+
+test('quiet hours detect across midnight', () => {
+  assert.equal(inQuietHours(date('2024-01-01T22:30:00Z'), settings), true);
+  assert.equal(inQuietHours(date('2024-01-01T19:30:00Z'), settings), false);
+});
+
+test('next send time schedules 07:30', () => {
+  const ns = nextSendTime(date('2024-01-01T22:30:00Z'), settings);
+  const str = ns.toLocaleString('de-DE', { timeZone: 'Europe/Berlin', hour: '2-digit', minute: '2-digit', hour12: false });
+  assert.equal(str, '07:30');
+});
+
+test('rate limit works', () => {
+  resetRateLimit();
+  const t = date('2024-01-01T10:00:00Z');
+  assert.equal(checkRateLimit('u1', 'medium', t, 10), true);
+  assert.equal(checkRateLimit('u1', 'medium', new Date(t.getTime() + 5 * 60000), 10), false);
+  assert.equal(checkRateLimit('u1', 'medium', new Date(t.getTime() + 11 * 60000), 10), true);
+});
+
+test('dedupe works', () => {
+  resetDedupe();
+  assert.equal(checkDedupe('key1'), true);
+  assert.equal(checkDedupe('key1'), false);
+});
+
+test('payload i18n with fallback', () => {
+  const msg = buildMessage({ type: 'JOB_ACCEPTED', data: { helper_name: 'Max', job_title: 'Test' }, language: 'en' });
+  assert.ok(msg.includes('Max'));
+  assert.ok(msg.includes('Test'));
+});


### PR DESCRIPTION
## Summary
- add notification rules with quiet hours, rate limiting, and dedupe logic
- add payload builder with DE/EN translations
- scaffold API endpoints, queue, adapters, and supabase functions
- create database tables and policies for notification events and settings
- document env vars for mail/push services

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68991475cb2c832ea2391b2e49a64aaa