### PR TITLE
feat: use provided logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,11 @@
 <html lang="de">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+    <link
+      rel="icon"
+      type="image/png"
+      href="http://mutuus-app.de/assets/logopng.png"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Mutuus App</title>
   </head>

--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -47,7 +47,7 @@ export const DashboardHeader = () => {
           <div className="flex items-center">
             <div className="mr-3 cursor-pointer hover-lift floating glow-blue" onClick={() => navigate('/dashboard')}>
               <img
-                src="/lovable-uploads/1a307408-cad9-4e5f-baa9-47e9004e7453.png"
+                src="http://mutuus-app.de/assets/logopng.png"
                 alt="Mutuus"
                 className="h-10 w-auto"
               />

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -178,9 +178,9 @@ const Auth = () => {
       <div className="w-full max-w-md">
         {/* Logo */}
         <div className="text-center mb-8 scroll-fade-in">
-          <img 
-            src="/lovable-uploads/297ee6c8-01e0-4f29-ab9c-61eef3186daf.png" 
-            alt="Mutuus" 
+          <img
+            src="http://mutuus-app.de/assets/logopng.png"
+            alt="Mutuus"
             className="h-16 w-auto mx-auto mb-4 floating glow-blue"
           />
           <h1 className="text-3xl font-bold text-white text-glow">Willkommen bei Mutuus</h1>

--- a/src/pages/TutorialLesson.tsx
+++ b/src/pages/TutorialLesson.tsx
@@ -43,7 +43,7 @@ const TutorialLesson = () => {
         {
           title: 'Willkommen im Dashboard',
           content: 'Das Dashboard ist Ihr Kontrollzentrum. Hier sehen Sie alle wichtigen Informationen auf einen Blick.',
-          image: '/lovable-uploads/297ee6c8-01e0-4f29-ab9c-61eef3186daf.png',
+          image: 'http://mutuus-app.de/assets/logopng.png',
           tips: [
             'Das Dashboard zeigt Ihre aktuellen Stats',
             'Neue Jobs werden hier prominent angezeigt',


### PR DESCRIPTION
## Summary
- reference external Mutuus logo as favicon
- swap in new logo image across auth, dashboard header and tutorial

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689914e41b14832e861973a94872d73a