### PR TITLE
feat: consolidate job pages into single tabbed view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,12 +10,10 @@ import { ProtectedRoute } from "@/components/ProtectedRoute";
 import Index from "./pages/Index";
 import Dashboard from "./pages/Dashboard";
 import Auth from "./pages/Auth";
-import Map from "./pages/Map";
 import Jobs from "./pages/Jobs";
 import Profile from "./pages/Profile";
 import Invite from "./pages/Invite";
 import Wallet from "./pages/Wallet";
-import MyJobs from "./pages/MyJobs";
 import Missions from "./pages/Missions";
 import Ranking from "./pages/Ranking";
 import Tutorial from "./pages/Tutorial";
@@ -39,11 +37,6 @@ const App = () => (
                   <Dashboard />
                 </ProtectedRoute>
               } />
-              <Route path="/map" element={
-                <ProtectedRoute>
-                  <Map />
-                </ProtectedRoute>
-              } />
               <Route path="/jobs" element={
                 <ProtectedRoute>
                   <Jobs />
@@ -62,11 +55,6 @@ const App = () => (
               <Route path="/wallet" element={
                 <ProtectedRoute>
                   <Wallet />
-                </ProtectedRoute>
-              } />
-              <Route path="/my-jobs" element={
-                <ProtectedRoute>
-                  <MyJobs />
                 </ProtectedRoute>
               } />
               <Route path="/missions" element={

--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FolderOpen, CheckSquare, Gift, MapPin, Users, WalletIcon, Menu, Trophy, Briefcase, BookOpen } from 'lucide-react';
+import { FolderOpen, CheckSquare, Gift, Users, WalletIcon, Menu, Trophy, BookOpen } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useNavigate, useLocation } from 'react-router-dom';
 import {
@@ -17,9 +17,7 @@ export const DashboardHeader = () => {
 
   const navigationItems = [
     { name: 'Dashboard', href: '/dashboard', icon: FolderOpen },
-    { name: 'Karte', href: '/map', icon: MapPin },
     { name: 'Jobs', href: '/jobs', icon: CheckSquare },
-    { name: 'Meine Jobs', href: '/my-jobs', icon: Briefcase },
     { name: 'Campus', href: '/tutorial', icon: BookOpen },
     { name: 'Ranking', href: '/ranking', icon: Trophy },
     { name: 'Profil', href: '/profile', icon: Users },

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -198,9 +198,9 @@ const Dashboard = () => {
                 >
                   Missionen
                 </Button>
-                <Button 
-                  onClick={() => window.location.href = '/map'} 
-                  variant="outline" 
+                <Button
+                  onClick={() => window.location.href = '/jobs'}
+                  variant="outline"
                   className="w-full btn-futuristic hover-lift"
                 >
                   Karte öffnen

--- a/src/pages/JobSearch.tsx
+++ b/src/pages/JobSearch.tsx
@@ -1,0 +1,228 @@
+
+import React, { useState, useEffect } from 'react';
+import { Search, Filter, MapPin, Plus, Clock } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { DashboardHeader } from '@/components/DashboardHeader';
+import { JobCard } from '@/components/JobCard';
+import { useJobs } from '@/hooks/useJobs';
+
+const JobSearch = ({ showHeader = true }: { showHeader?: boolean }) => {
+  const { jobs, loading, applyForJob } = useJobs();
+  const [filteredJobs, setFilteredJobs] = useState(jobs);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [selectedCategory, setSelectedCategory] = useState('all');
+  const [selectedJobType, setSelectedJobType] = useState('all');
+
+  useEffect(() => {
+    let filtered = jobs;
+
+    if (searchTerm) {
+      filtered = filtered.filter(job => 
+        job.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        job.description?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        job.location.toLowerCase().includes(searchTerm.toLowerCase())
+      );
+    }
+
+    if (selectedCategory !== 'all') {
+      filtered = filtered.filter(job => job.category === selectedCategory);
+    }
+
+    if (selectedJobType !== 'all') {
+      filtered = filtered.filter(job => job.job_type === selectedJobType);
+    }
+
+    setFilteredJobs(filtered);
+  }, [jobs, searchTerm, selectedCategory, selectedJobType]);
+
+  const handleApply = async (jobId: string) => {
+    await applyForJob(jobId, 'Ich interessiere mich für diesen Job!');
+  };
+
+  const handleViewJob = (jobId: string) => {
+    console.log('View job:', jobId);
+    // In a real app, this would navigate to job details page
+  };
+
+  const categories = [
+    'Haushalt',
+    'Garten',
+    'Umzug',
+    'Reparatur',
+    'Einkaufen',
+    'Tierpflege',
+    'Sonstiges'
+  ];
+
+  if (loading) {
+    return (
+      <div className={showHeader ? "min-h-screen bg-gray-900" : ""}>
+        {showHeader && <DashboardHeader />}
+        <div className="container mx-auto px-4 py-8 flex items-center justify-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-blue-400"></div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={showHeader ? "min-h-screen bg-gray-900" : ""}>
+      {showHeader && <DashboardHeader />}
+
+      <div className={showHeader ? "container mx-auto px-4 py-6" : ""}>
+        {/* Header */}
+        <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-8 scroll-fade-in">
+          <div>
+            <h1 className="text-3xl font-bold text-white mb-2 text-glow">Jobs finden</h1>
+            <p className="text-gray-400">Entdecken Sie interessante Aufgaben in Ihrer Nähe</p>
+          </div>
+          
+          <Button
+            onClick={() => window.location.href = '/jobs'}
+            className="mt-4 sm:mt-0 btn-futuristic glow-blue hover-lift"
+          >
+            <Plus className="w-4 h-4 mr-2" />
+            Job erstellen
+          </Button>
+        </div>
+
+        {/* Filters */}
+        <Card className="bg-gray-800 border-gray-700 mb-6 card-futuristic hover-lift glow-blue scroll-slide-left">
+          <CardHeader>
+            <CardTitle className="text-white flex items-center hover-glow">
+              <Filter className="w-5 h-5 mr-2 text-blue-400" />
+              Filter & Suche
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+              <div className="relative">
+                <Search className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
+                <Input
+                  placeholder="Nach Jobs suchen..."
+                  className="pl-10 bg-gray-700 border-gray-600 text-white"
+                  value={searchTerm}
+                  onChange={(e) => setSearchTerm(e.target.value)}
+                />
+              </div>
+
+              <Select value={selectedJobType} onValueChange={setSelectedJobType}>
+                <SelectTrigger className="bg-gray-700 border-gray-600 text-white">
+                  <SelectValue placeholder="Job-Typ" />
+                </SelectTrigger>
+                <SelectContent className="bg-gray-700 border-gray-600">
+                  <SelectItem value="all">Alle Typen</SelectItem>
+                  <SelectItem value="good_deeds">Good Deeds</SelectItem>
+                  <SelectItem value="kein_bock">KeinBock Jobs</SelectItem>
+                </SelectContent>
+              </Select>
+
+              <Select value={selectedCategory} onValueChange={setSelectedCategory}>
+                <SelectTrigger className="bg-gray-700 border-gray-600 text-white">
+                  <SelectValue placeholder="Kategorie" />
+                </SelectTrigger>
+                <SelectContent className="bg-gray-700 border-gray-600">
+                  <SelectItem value="all">Alle Kategorien</SelectItem>
+                  {categories.map(category => (
+                    <SelectItem key={category} value={category}>{category}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+
+              <Button 
+                variant="outline" 
+                className="btn-futuristic hover-lift"
+                onClick={() => {
+                  setSearchTerm('');
+                  setSelectedCategory('all');
+                  setSelectedJobType('all');
+                }}
+              >
+                Filter zurücksetzen
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Stats */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+          <Card className="bg-gray-800 border-gray-700 card-futuristic hover-lift glow-blue scroll-slide-left delay-100">
+            <CardContent className="p-4 text-center">
+              <div className="text-2xl font-bold text-blue-400 floating">{filteredJobs.length}</div>
+              <div className="text-sm text-gray-400">Gefundene Jobs</div>
+            </CardContent>
+          </Card>
+          
+          <Card className="bg-gray-800 border-gray-700 card-futuristic hover-lift glow-orange scroll-slide-left delay-200">
+            <CardContent className="p-4 text-center">
+              <div className="text-2xl font-bold text-orange-400 floating">
+                {filteredJobs.filter(j => j.job_type === 'good_deeds').length}
+              </div>
+              <div className="text-sm text-gray-400">Good Deeds</div>
+            </CardContent>
+          </Card>
+          
+          <Card className="bg-gray-800 border-gray-700 card-futuristic hover-lift glow-green scroll-slide-left delay-300">
+            <CardContent className="p-4 text-center">
+              <div className="text-2xl font-bold text-green-400 floating">
+                {filteredJobs.filter(j => j.job_type === 'kein_bock').length}
+              </div>
+              <div className="text-sm text-gray-400">KeinBock Jobs</div>
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Jobs Grid */}
+        {filteredJobs.length === 0 ? (
+          <Card className="bg-gray-800 border-gray-700 card-futuristic hover-lift glow-blue scroll-fade-in">
+            <CardContent className="p-8 text-center">
+              <MapPin className="w-16 h-16 text-gray-600 mx-auto mb-4 floating" />
+              <h3 className="text-lg font-medium text-white mb-2">Keine Jobs gefunden</h3>
+              <p className="text-gray-400 mb-6">
+                {searchTerm || selectedCategory !== 'all' || selectedJobType !== 'all'
+                  ? 'Versuchen Sie andere Suchkriterien'
+                  : 'Aktuell sind keine Jobs in Ihrer Nähe verfügbar'
+                }
+              </p>
+              <Button
+                onClick={() => window.location.href = '/jobs'}
+                className="btn-futuristic glow-blue hover-lift"
+              >
+                <MapPin className="w-4 h-4 mr-2" />
+                Karte erkunden
+              </Button>
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {filteredJobs.map((job, index) => (
+              <div key={job.id} className={`scroll-scale-in delay-${(index % 9 + 1) * 100}`}>
+                <JobCard
+                  job={job}
+                  onApply={handleApply}
+                  onView={handleViewJob}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Load More */}
+        {filteredJobs.length > 0 && (
+          <div className="text-center mt-8 scroll-fade-in delay-500">
+            <Button variant="outline" className="btn-futuristic hover-lift">
+              <Clock className="w-4 h-4 mr-2" />
+              Mehr Jobs laden
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default JobSearch;

--- a/src/pages/Jobs.tsx
+++ b/src/pages/Jobs.tsx
@@ -1,225 +1,31 @@
-
-import React, { useState, useEffect } from 'react';
-import { Search, Filter, MapPin, Plus, Clock } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import React from 'react';
+import Map from './Map';
+import JobSearch from './JobSearch';
+import MyJobs from './MyJobs';
 import { DashboardHeader } from '@/components/DashboardHeader';
-import { JobCard } from '@/components/JobCard';
-import { useJobs } from '@/hooks/useJobs';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
 const Jobs = () => {
-  const { jobs, loading, applyForJob } = useJobs();
-  const [filteredJobs, setFilteredJobs] = useState(jobs);
-  const [searchTerm, setSearchTerm] = useState('');
-  const [selectedCategory, setSelectedCategory] = useState('all');
-  const [selectedJobType, setSelectedJobType] = useState('all');
-
-  useEffect(() => {
-    let filtered = jobs;
-
-    if (searchTerm) {
-      filtered = filtered.filter(job => 
-        job.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        job.description?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        job.location.toLowerCase().includes(searchTerm.toLowerCase())
-      );
-    }
-
-    if (selectedCategory !== 'all') {
-      filtered = filtered.filter(job => job.category === selectedCategory);
-    }
-
-    if (selectedJobType !== 'all') {
-      filtered = filtered.filter(job => job.job_type === selectedJobType);
-    }
-
-    setFilteredJobs(filtered);
-  }, [jobs, searchTerm, selectedCategory, selectedJobType]);
-
-  const handleApply = async (jobId: string) => {
-    await applyForJob(jobId, 'Ich interessiere mich für diesen Job!');
-  };
-
-  const handleViewJob = (jobId: string) => {
-    console.log('View job:', jobId);
-    // In a real app, this would navigate to job details page
-  };
-
-  const categories = [
-    'Haushalt',
-    'Garten',
-    'Umzug',
-    'Reparatur',
-    'Einkaufen',
-    'Tierpflege',
-    'Sonstiges'
-  ];
-
-  if (loading) {
-    return (
-      <div className="min-h-screen bg-gray-900">
-        <DashboardHeader />
-        <div className="container mx-auto px-4 py-8 flex items-center justify-center">
-          <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-blue-400"></div>
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div className="min-h-screen bg-gray-900">
       <DashboardHeader />
-      
       <main className="container mx-auto px-4 py-6">
-        {/* Header */}
-        <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-8 scroll-fade-in">
-          <div>
-            <h1 className="text-3xl font-bold text-white mb-2 text-glow">Jobs finden</h1>
-            <p className="text-gray-400">Entdecken Sie interessante Aufgaben in Ihrer Nähe</p>
-          </div>
-          
-          <Button 
-            onClick={() => window.location.href = '/my-jobs'}
-            className="mt-4 sm:mt-0 btn-futuristic glow-blue hover-lift"
-          >
-            <Plus className="w-4 h-4 mr-2" />
-            Job erstellen
-          </Button>
-        </div>
-
-        {/* Filters */}
-        <Card className="bg-gray-800 border-gray-700 mb-6 card-futuristic hover-lift glow-blue scroll-slide-left">
-          <CardHeader>
-            <CardTitle className="text-white flex items-center hover-glow">
-              <Filter className="w-5 h-5 mr-2 text-blue-400" />
-              Filter & Suche
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-              <div className="relative">
-                <Search className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
-                <Input
-                  placeholder="Nach Jobs suchen..."
-                  className="pl-10 bg-gray-700 border-gray-600 text-white"
-                  value={searchTerm}
-                  onChange={(e) => setSearchTerm(e.target.value)}
-                />
-              </div>
-
-              <Select value={selectedJobType} onValueChange={setSelectedJobType}>
-                <SelectTrigger className="bg-gray-700 border-gray-600 text-white">
-                  <SelectValue placeholder="Job-Typ" />
-                </SelectTrigger>
-                <SelectContent className="bg-gray-700 border-gray-600">
-                  <SelectItem value="all">Alle Typen</SelectItem>
-                  <SelectItem value="good_deeds">Good Deeds</SelectItem>
-                  <SelectItem value="kein_bock">KeinBock Jobs</SelectItem>
-                </SelectContent>
-              </Select>
-
-              <Select value={selectedCategory} onValueChange={setSelectedCategory}>
-                <SelectTrigger className="bg-gray-700 border-gray-600 text-white">
-                  <SelectValue placeholder="Kategorie" />
-                </SelectTrigger>
-                <SelectContent className="bg-gray-700 border-gray-600">
-                  <SelectItem value="all">Alle Kategorien</SelectItem>
-                  {categories.map(category => (
-                    <SelectItem key={category} value={category}>{category}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-
-              <Button 
-                variant="outline" 
-                className="btn-futuristic hover-lift"
-                onClick={() => {
-                  setSearchTerm('');
-                  setSelectedCategory('all');
-                  setSelectedJobType('all');
-                }}
-              >
-                Filter zurücksetzen
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
-
-        {/* Stats */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
-          <Card className="bg-gray-800 border-gray-700 card-futuristic hover-lift glow-blue scroll-slide-left delay-100">
-            <CardContent className="p-4 text-center">
-              <div className="text-2xl font-bold text-blue-400 floating">{filteredJobs.length}</div>
-              <div className="text-sm text-gray-400">Gefundene Jobs</div>
-            </CardContent>
-          </Card>
-          
-          <Card className="bg-gray-800 border-gray-700 card-futuristic hover-lift glow-orange scroll-slide-left delay-200">
-            <CardContent className="p-4 text-center">
-              <div className="text-2xl font-bold text-orange-400 floating">
-                {filteredJobs.filter(j => j.job_type === 'good_deeds').length}
-              </div>
-              <div className="text-sm text-gray-400">Good Deeds</div>
-            </CardContent>
-          </Card>
-          
-          <Card className="bg-gray-800 border-gray-700 card-futuristic hover-lift glow-green scroll-slide-left delay-300">
-            <CardContent className="p-4 text-center">
-              <div className="text-2xl font-bold text-green-400 floating">
-                {filteredJobs.filter(j => j.job_type === 'kein_bock').length}
-              </div>
-              <div className="text-sm text-gray-400">KeinBock Jobs</div>
-            </CardContent>
-          </Card>
-        </div>
-
-        {/* Jobs Grid */}
-        {filteredJobs.length === 0 ? (
-          <Card className="bg-gray-800 border-gray-700 card-futuristic hover-lift glow-blue scroll-fade-in">
-            <CardContent className="p-8 text-center">
-              <MapPin className="w-16 h-16 text-gray-600 mx-auto mb-4 floating" />
-              <h3 className="text-lg font-medium text-white mb-2">Keine Jobs gefunden</h3>
-              <p className="text-gray-400 mb-6">
-                {searchTerm || selectedCategory !== 'all' || selectedJobType !== 'all'
-                  ? 'Versuchen Sie andere Suchkriterien'
-                  : 'Aktuell sind keine Jobs in Ihrer Nähe verfügbar'
-                }
-              </p>
-              <Button 
-                onClick={() => window.location.href = '/map'} 
-                className="btn-futuristic glow-blue hover-lift"
-              >
-                <MapPin className="w-4 h-4 mr-2" />
-                Karte erkunden
-              </Button>
-            </CardContent>
-          </Card>
-        ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {filteredJobs.map((job, index) => (
-              <div key={job.id} className={`scroll-scale-in delay-${(index % 9 + 1) * 100}`}>
-                <JobCard
-                  job={job}
-                  onApply={handleApply}
-                  onView={handleViewJob}
-                />
-              </div>
-            ))}
-          </div>
-        )}
-
-        {/* Load More */}
-        {filteredJobs.length > 0 && (
-          <div className="text-center mt-8 scroll-fade-in delay-500">
-            <Button variant="outline" className="btn-futuristic hover-lift">
-              <Clock className="w-4 h-4 mr-2" />
-              Mehr Jobs laden
-            </Button>
-          </div>
-        )}
+        <Tabs defaultValue="map" className="w-full">
+          <TabsList className="grid w-full grid-cols-3 bg-gray-800 border-gray-700">
+            <TabsTrigger value="map" className="data-[state=active]:bg-blue-600">Karte</TabsTrigger>
+            <TabsTrigger value="search" className="data-[state=active]:bg-blue-600">Jobs</TabsTrigger>
+            <TabsTrigger value="my-jobs" className="data-[state=active]:bg-blue-600">Meine Jobs</TabsTrigger>
+          </TabsList>
+          <TabsContent value="map">
+            <Map showHeader={false} />
+          </TabsContent>
+          <TabsContent value="search">
+            <JobSearch showHeader={false} />
+          </TabsContent>
+          <TabsContent value="my-jobs">
+            <MyJobs showHeader={false} />
+          </TabsContent>
+        </Tabs>
       </main>
     </div>
   );

--- a/src/pages/Map.tsx
+++ b/src/pages/Map.tsx
@@ -76,7 +76,7 @@ const mockJobs = [
   }
 ];
 
-const Map = () => {
+const Map = ({ showHeader = true }: { showHeader?: boolean }) => {
   const [viewMode, setViewMode] = useState<'map' | 'list'>('map');
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedCategory, setSelectedCategory] = useState<string>('all');
@@ -115,10 +115,10 @@ const Map = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gray-900">
-      <DashboardHeader />
-      
-      <main className="container mx-auto px-4 py-6">
+    <div className={showHeader ? "min-h-screen bg-gray-900" : ""}>
+      {showHeader && <DashboardHeader />}
+
+      <div className={showHeader ? "container mx-auto px-4 py-6" : ""}>
         {/* Header Section */}
         <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-6">
           <div>
@@ -302,7 +302,7 @@ const Map = () => {
             </Dialog>
           </div>
         )}
-      </main>
+      </div>
     </div>
   );
 };

--- a/src/pages/MyJobs.tsx
+++ b/src/pages/MyJobs.tsx
@@ -10,7 +10,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { DashboardHeader } from '@/components/DashboardHeader';
 
-const MyJobs = () => {
+const MyJobs = ({ showHeader = true }: { showHeader?: boolean }) => {
   const [activeTab, setActiveTab] = useState('active');
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState('all');
@@ -99,10 +99,10 @@ const MyJobs = () => {
   });
 
   return (
-    <div className="min-h-screen bg-gray-900">
-      <DashboardHeader />
-      
-      <main className="container mx-auto px-4 py-6">
+    <div className={showHeader ? "min-h-screen bg-gray-900" : ""}>
+      {showHeader && <DashboardHeader />}
+
+      <div className={showHeader ? "container mx-auto px-4 py-6" : ""}>
         {/* Header */}
         <div className="mb-8">
           <h1 className="text-3xl font-bold text-white mb-2">Meine Jobs</h1>
@@ -323,7 +323,7 @@ const MyJobs = () => {
             )}
           </TabsContent>
         </Tabs>
-      </main>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- replace separate Map, Jobs, and My Jobs views with a unified Jobs page featuring tabs
- simplify header navigation to a single Jobs entry
- clean up routes and links to point to /jobs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any and other lint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898dd9977f8832e82fb4ab78f3df9ee