### PR TITLE
fix: prevent horizontal scroll and align mobile menu

### DIFF
--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -82,7 +82,7 @@ export const DashboardHeader = () => {
                     <Menu className="w-4 h-4 mr-2" />
                     Menü
                   </NavigationMenuTrigger>
-                  <NavigationMenuContent className="w-56 bg-gray-800 border-gray-700 glow-blue">
+                  <NavigationMenuContent className="w-56 bg-gray-800 border-gray-700 glow-blue left-auto right-0">
                     <div className="p-2">
                       {navigationItems.map((item, index) => (
                         <NavigationMenuLink

--- a/src/index.css
+++ b/src/index.css
@@ -99,7 +99,7 @@
   }
 
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground overflow-x-hidden;
   }
 }
 


### PR DESCRIPTION
## Summary
- hide horizontal overflow to stop sideways scrolling
- align mobile menu content with viewport edge

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_6898da1a9504832e9d855cd2de011b3e