### PR TITLE
feat: enable optional https server

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ VITE_SUPABASE_ANON_KEY=
 VITE_STRIPE_SECRET_KEY=
 ```
 
+### HTTPS configuration
+
+To run the Stripe server over HTTPS, provide paths to your SSL key and certificate using the `SSL_KEY_PATH` and `SSL_CERT_PATH` environment variables. When these variables are set, the server will start with HTTPS; otherwise it falls back to HTTP.
+
 ## Job creation form
 
 A basic job creation form is available at `/jobs/new`. It validates input with Zod and stores new jobs in Supabase.


### PR DESCRIPTION
## Summary
- allow Stripe server to start over HTTPS when SSL_CERT_PATH and SSL_KEY_PATH are provided
- document SSL configuration for local server

## Testing
- `npm test` *(fails: SyntaxError in lib/notify/payloads.js)*

------
https://chatgpt.com/codex/tasks/task_e_68999bf88830832eae402b117f55b75b