### PR TITLE
feat: add Google and Facebook social logins

### DIFF
--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -8,6 +8,7 @@ interface AuthContextType {
   session: Session | null;
   loading: boolean;
   signIn: (email: string, password: string) => Promise<void>;
+  signInWithProvider: (provider: 'google' | 'facebook') => Promise<void>;
   signUp: (email: string, password: string, userData?: any) => Promise<void>;
   signOut: () => Promise<void>;
   resetPassword: (email: string) => Promise<void>;
@@ -124,6 +125,23 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         title: "Erfolgreich angemeldet",
         description: "Willkommen zurück!",
       });
+    } catch (error: any) {
+      toast({
+        title: "Anmeldung fehlgeschlagen",
+        description: error.message,
+        variant: "destructive",
+      });
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const signInWithProvider = async (provider: 'google' | 'facebook') => {
+    try {
+      setLoading(true);
+      const { error } = await supabase.auth.signInWithOAuth({ provider });
+      if (error) throw error;
     } catch (error: any) {
       toast({
         title: "Anmeldung fehlgeschlagen",
@@ -265,6 +283,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     session,
     loading,
     signIn,
+    signInWithProvider,
     signUp,
     signOut,
     resetPassword,

--- a/src/hooks/useSecureAuth.tsx
+++ b/src/hooks/useSecureAuth.tsx
@@ -17,6 +17,7 @@ interface AuthContextType {
   loginAttempts: number;
   isLocked: boolean;
   signIn: (email: string, password: string) => Promise<void>;
+  signInWithProvider: (provider: 'google' | 'facebook') => Promise<void>;
   signUp: (email: string, password: string, userData?: { first_name?: string; last_name?: string }) => Promise<void>;
   signOut: () => Promise<void>;
   resetPassword: (email: string) => Promise<void>;
@@ -144,6 +145,23 @@ export function SecureAuthProvider({ children }: { children: ReactNode }) {
         title: "Erfolgreich angemeldet",
         description: "Willkommen zurück!",
       });
+    } catch (error: any) {
+      toast({
+        title: "Anmeldung fehlgeschlagen",
+        description: error.message,
+        variant: "destructive",
+      });
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const signInWithProvider = async (provider: 'google' | 'facebook') => {
+    try {
+      setLoading(true);
+      const { error } = await supabase.auth.signInWithOAuth({ provider });
+      if (error) throw error;
     } catch (error: any) {
       toast({
         title: "Anmeldung fehlgeschlagen",
@@ -320,6 +338,7 @@ export function SecureAuthProvider({ children }: { children: ReactNode }) {
     loginAttempts,
     isLocked,
     signIn,
+    signInWithProvider,
     signUp,
     signOut,
     resetPassword,

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -7,11 +7,11 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useAuth } from '@/hooks/useAuth';
-import { Eye, EyeOff, Mail, Lock, User, Loader2 } from 'lucide-react';
+import { Eye, EyeOff, Mail, Lock, User, Loader2, Chrome, Facebook } from 'lucide-react';
 
 const Auth = () => {
   const navigate = useNavigate();
-  const { user, signIn, signUp, resetPassword, loading } = useAuth();
+  const { user, signIn, signUp, resetPassword, signInWithProvider, loading } = useAuth();
   const [isLoading, setIsLoading] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
@@ -332,6 +332,27 @@ const Auth = () => {
                       </button>
                     </div>
                   </form>
+                  <div className="mt-6 space-y-3">
+                    <div className="text-center text-gray-400 text-sm">oder</div>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      className="w-full flex items-center justify-center"
+                      onClick={() => signInWithProvider('google')}
+                    >
+                      <Chrome className="h-4 w-4 mr-2" />
+                      Mit Google anmelden
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      className="w-full flex items-center justify-center"
+                      onClick={() => signInWithProvider('facebook')}
+                    >
+                      <Facebook className="h-4 w-4 mr-2" />
+                      Mit Facebook anmelden
+                    </Button>
+                  </div>
                 </TabsContent>
 
               <TabsContent value="signup">


### PR DESCRIPTION
## Summary
- add OAuth signInWithProvider for Google/Facebook in auth hooks
- expose social login buttons on the sign-in screen

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any...)*

------
https://chatgpt.com/codex/tasks/task_e_6899a4ae2010832eb4f17c7b2348cf97