### PR TITLE
Integrate Stripe checkout and remove mock data

### DIFF
--- a/src/components/CheckoutForm.tsx
+++ b/src/components/CheckoutForm.tsx
@@ -1,0 +1,59 @@
+import { CardElement, useStripe, useElements } from '@stripe/react-stripe-js';
+import { useState } from 'react';
+
+interface CheckoutFormProps {
+  amount: number; // amount in cents
+  onSuccess?: () => void;
+}
+
+const CheckoutForm = ({ amount, onSuccess }: CheckoutFormProps) => {
+  const stripe = useStripe();
+  const elements = useElements();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!stripe || !elements || !amount) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch('/create-payment-intent', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ amount }),
+      });
+      const { clientSecret } = await response.json();
+      const result = await stripe.confirmCardPayment(clientSecret, {
+        payment_method: {
+          card: elements.getElement(CardElement)!,
+        },
+      });
+      if (result.error) {
+        setError(result.error.message || 'Zahlung fehlgeschlagen');
+      } else if (result.paymentIntent?.status === 'succeeded') {
+        onSuccess?.();
+      }
+    } catch (err: any) {
+      setError('Zahlung fehlgeschlagen');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <CardElement className="p-2 bg-gray-700 rounded" />
+      {error && <p className="text-red-500 text-sm">{error}</p>}
+      <button
+        type="submit"
+        disabled={!stripe || loading || amount <= 0}
+        className="w-full bg-green-600 hover:bg-green-700 text-white py-2 rounded disabled:opacity-50"
+      >
+        {loading ? 'Verarbeite...' : 'Bezahlen'}
+      </button>
+    </form>
+  );
+};
+
+export default CheckoutForm;

--- a/src/hooks/useMissions.tsx
+++ b/src/hooks/useMissions.tsx
@@ -184,8 +184,8 @@ export function useMissions() {
       //   .from('mission-photos')
       //   .upload(fileName, file);
 
-      // For demo purposes, return a placeholder URL
-      return `https://example.com/mission-photos/${fileName}`;
+      // For demo purposes, no actual upload is performed
+      return '';
     } catch (error: any) {
       toast({
         title: "Upload-Fehler",

--- a/stripe-demo/src/App.test.js
+++ b/stripe-demo/src/App.test.js
@@ -1,8 +1,0 @@
-import { render, screen } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});


### PR DESCRIPTION
## Summary
- Add Stripe payment-intent endpoint and server-side support
- Introduce reusable CheckoutForm component and integrate in Wallet for top-ups
- Remove mock job and transaction data, using live data and cleaner placeholders

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, parsing errors in stripe-demo and tailwind config)*

------
https://chatgpt.com/codex/tasks/task_e_6899ad06f410832e9298b25910331528