### PR TITLE
Add job timer, notifications, and payment capture on completion

### DIFF
--- a/src/components/JobCard.tsx
+++ b/src/components/JobCard.tsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
 import { Calendar, MapPin, Euro, Flame, User, Clock } from 'lucide-react';
+import { JobTimer } from './JobTimer';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -92,10 +93,20 @@ export function JobCard({ job, onApply, onView }: JobCardProps) {
           )}
 
           {job.due_date && (
-            <div className="flex items-center text-sm text-gray-500">
-              <Calendar className="w-4 h-4 mr-2" />
-              Bis {formatDate(job.due_date)}
-            </div>
+            <>
+              <div className="flex items-center text-sm text-gray-500">
+                <Calendar className="w-4 h-4 mr-2" />
+                Bis {formatDate(job.due_date)}
+              </div>
+              <div className="flex items-center text-sm text-gray-500">
+                <Clock className="w-4 h-4 mr-2" />
+                <JobTimer
+                  startTime={new Date()}
+                  duration={(new Date(job.due_date).getTime() - Date.now()) / 60000}
+                  mode="countdown"
+                />
+              </div>
+            </>
           )}
         </div>
 


### PR DESCRIPTION
## Summary
- show countdown timer for job deadlines
- notify job creators about new applications and workers about status changes
- capture payment when provider marks job as completed

## Testing
- `npm run lint` *(fails: Unexpected any, parsing errors, forbidden require)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899af5e2d54832ebd70001617e42909