### PR TITLE
Fix job creation button link

### DIFF
--- a/src/pages/Jobs.tsx
+++ b/src/pages/Jobs.tsx
@@ -81,8 +81,8 @@ const Jobs = () => {
             <p className="text-gray-400">Entdecken Sie interessante Aufgaben in Ihrer Nähe</p>
           </div>
           
-          <Button 
-            onClick={() => window.location.href = '/my-jobs'}
+          <Button
+            onClick={() => window.location.href = '/jobs/new'}
             className="mt-4 sm:mt-0 btn-futuristic glow-blue hover-lift"
           >
             <Plus className="w-4 h-4 mr-2" />


### PR DESCRIPTION
## Summary
- Correct job creation button to navigate to `/jobs/new`

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any...)*

------
https://chatgpt.com/codex/tasks/task_e_689a78042bf4832eb93144cca3d3f1e5