### PR TITLE
Fix job payment capture identifier

### DIFF
--- a/src/hooks/useJobs.tsx
+++ b/src/hooks/useJobs.tsx
@@ -290,7 +290,8 @@ export function useJobs() {
           await fetch('/api/payment/capture', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ ticket_id: jobId }),
+            // The capture endpoint now expects a `job_id` field
+            body: JSON.stringify({ job_id: jobId }),
           });
         } catch (err) {
           console.error('Payment capture failed', err);


### PR DESCRIPTION
## Summary
- align payment capture endpoint with job-based payments
- send job_id when capturing payment after job completion

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a7ce0ed0c832e89e3de46331776fb