### PR TITLE
fix tests for notifications and json imports

### DIFF
--- a/lib/notify/payloads.js
+++ b/lib/notify/payloads.js
@@ -1,5 +1,5 @@
-import de from '../i18n/de.json' assert { type: 'json' };
-import en from '../i18n/en.json' assert { type: 'json' };
+import de from '../i18n/de.json' with { type: 'json' };
+import en from '../i18n/en.json' with { type: 'json' };
 
 const translations = { de, en };
 

--- a/supabase/functions/send-notification/index.test.ts
+++ b/supabase/functions/send-notification/index.test.ts
@@ -1,31 +1,29 @@
-import {
-  assertEquals,
-  assertStringIncludes,
-} from 'https://deno.land/std@0.224.0/assert/mod.ts';
+import test from 'node:test';
+import assert from 'node:assert/strict';
 import { buildNotificationContent } from './index.ts';
 
-Deno.test('NEW_APPLICATION template de', () => {
+test('NEW_APPLICATION template de', () => {
   const content = buildNotificationContent('NEW_APPLICATION', {
     job_title: 'Gartenhilfe',
     applicant_name: 'Max',
     lang: 'de',
   });
-  assertEquals(content?.email.subject, 'Neue Bewerbung für Gartenhilfe');
-  assertStringIncludes(content?.email.html ?? '', 'Gartenhilfe');
-  assertStringIncludes(content?.email.html ?? '', 'Max');
-  assertEquals(content?.push.title, 'Neue Bewerbung');
-  assertEquals(content?.push.body, 'Max hat sich beworben');
+  assert.equal(content?.email.subject, 'Neue Bewerbung für Gartenhilfe');
+  assert.ok(content?.email.html?.includes('Gartenhilfe'));
+  assert.ok(content?.email.html?.includes('Max'));
+  assert.equal(content?.push.title, 'Neue Bewerbung');
+  assert.equal(content?.push.body, 'Max hat sich beworben');
 });
 
-Deno.test('NEW_APPLICATION template en', () => {
+test('NEW_APPLICATION template en', () => {
   const content = buildNotificationContent('NEW_APPLICATION', {
     job_title: 'Gardener',
     applicant_name: 'John',
   });
-  assertEquals(content?.email.subject, 'New application for Gardener');
-  assertStringIncludes(content?.email.html ?? '', 'Gardener');
-  assertStringIncludes(content?.email.html ?? '', 'John');
-  assertEquals(content?.push.title, 'New application');
-  assertEquals(content?.push.body, 'John has applied');
+  assert.equal(content?.email.subject, 'New application for Gardener');
+  assert.ok(content?.email.html?.includes('Gardener'));
+  assert.ok(content?.email.html?.includes('John'));
+  assert.equal(content?.push.title, 'New application');
+  assert.equal(content?.push.body, 'John has applied');
 });
 


### PR DESCRIPTION
## Summary
- use `with { type: "json" }` JSON imports
- adapt Deno notification function for Node tests and dynamically import Supabase client
- rewrite notification function tests using `node:test`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a7d0f29a4832eb9a3d532930b9355