### PR TITLE
feat: show job form modal on job creation

### DIFF
--- a/src/components/forms/JobForm.tsx
+++ b/src/components/forms/JobForm.tsx
@@ -39,7 +39,7 @@ export const jobSchema = z.object({
 
 export type JobFormValues = z.infer<typeof jobSchema>;
 
-export function JobForm() {
+export function JobForm({ onSuccess }: { onSuccess?: () => void }) {
   const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
   const { createJob } = useJobs();
@@ -69,6 +69,7 @@ export function JobForm() {
         due_date: deadline.toISOString(),
       });
       toast.success('Job created');
+      onSuccess?.();
       navigate('/jobs');
       return job;
     } catch (error: any) {

--- a/src/pages/Jobs.tsx
+++ b/src/pages/Jobs.tsx
@@ -9,6 +9,8 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { DashboardHeader } from '@/components/DashboardHeader';
 import { JobCard } from '@/components/JobCard';
 import { useJobs } from '@/hooks/useJobs';
+import { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import JobForm from '@/components/forms/JobForm';
 
 const Jobs = () => {
   const { jobs, loading, applyForJob, recordJobView } = useJobs();
@@ -16,6 +18,7 @@ const Jobs = () => {
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedCategory, setSelectedCategory] = useState('all');
   const [selectedJobType, setSelectedJobType] = useState('all');
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
 
   useEffect(() => {
     let filtered = jobs;
@@ -82,13 +85,20 @@ const Jobs = () => {
             <p className="text-gray-400">Entdecken Sie interessante Aufgaben in Ihrer Nähe</p>
           </div>
           
-          <Button
-            onClick={() => window.location.href = '/jobs/new'}
-            className="mt-4 sm:mt-0 btn-futuristic glow-blue hover-lift"
-          >
-            <Plus className="w-4 h-4 mr-2" />
-            Job erstellen
-          </Button>
+          <Dialog open={isCreateModalOpen} onOpenChange={setIsCreateModalOpen}>
+            <DialogTrigger asChild>
+              <Button className="mt-4 sm:mt-0 btn-futuristic glow-blue hover-lift">
+                <Plus className="w-4 h-4 mr-2" />
+                Job erstellen
+              </Button>
+            </DialogTrigger>
+            <DialogContent className="bg-gray-800 border-gray-700">
+              <DialogHeader>
+                <DialogTitle className="text-white">Neuen Job erstellen</DialogTitle>
+              </DialogHeader>
+              <JobForm onSuccess={() => setIsCreateModalOpen(false)} />
+            </DialogContent>
+          </Dialog>
         </div>
 
         {/* Filters */}


### PR DESCRIPTION
## Summary
- open job creation form in a dialog from the Jobs page
- allow JobForm to notify when a job is created

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, parsing errors, forbidden require)*

------
https://chatgpt.com/codex/tasks/task_e_689bfe2a09cc832e987bf09c734103da